### PR TITLE
Updates for new version of usdt and returns probe registration status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-dtrace"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 description = "Forward slog messages to DTrace"
@@ -12,7 +12,7 @@ serde = "1"
 serde_json = "1"
 slog = "2"
 chrono = { version = "0.4", features = [ "serde" ] }
-usdt = "0.1.17"
+usdt = "0.2"
 
 [dev-dependencies]
 slog-async = "2"


### PR DESCRIPTION
- Bumps usdt to v0.2.0. Renames provider/probes using formatting options
  and updates calls to the probe macros.
- Previous versions returned a Result from creating a drain, with the
  error from registering the probes propagated to the caller. This is
  OK, but doesn't give the caller any choice in how to handle failure.
  This returns the result of registering to the caller instead of always
  regteruning an Error.